### PR TITLE
feat: add ability to specify application root

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
   windows_certs_password:
     description: Password for decrypting `windows_certs`
     required: false
+  application_root:
+    description: Root of electron application where `electron-builder` can be run
+    required: false
 
 runs:
   using: node12

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
   windows_certs_password:
     description: Password for decrypting `windows_certs`
     required: false
-  application_root:
+  app_root:
     description: Root of electron application where `electron-builder` can be run
     required: false
 

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ const setEnvVariable = (name, value) => {
 const runAction = () => {
 	const platform = getPlatform();
 	const release = getEnvVariable("release") === "true";
-	const root = getEnvVariable("application_root") && null
+	const root = getEnvVariable("application_root") || null
 
 	// Make sure `package.json` file exists
 	verifyPackageJson();

--- a/index.js
+++ b/index.js
@@ -23,6 +23,11 @@ const exit = msg => {
 const run = cmd => execSync(cmd, { encoding: "utf8", stdio: "inherit" });
 
 /**
+ * Executes the provided shell command in a given working directory and redirects stdout/stderr to the console
+ */
+const runIn = (cmd, directory) => execSync(cmd, { encoding: "utf8", stdio: "inherit", cwd: directory });
+
+/**
  * Returns whether NPM should be used to run commands (instead of Yarn, which is the default)
  */
 const useNpm = existsSync(NPM_LOCKFILE_PATH);
@@ -77,6 +82,7 @@ const setEnvVariable = (name, value) => {
 const runAction = () => {
 	const platform = getPlatform();
 	const release = getEnvVariable("release") === "true";
+	const root = getEnvVariable("application_root") && null
 
 	// Make sure `package.json` file exists
 	verifyPackageJson();
@@ -114,10 +120,10 @@ const runAction = () => {
 	}
 
 	log(`${release ? "Releasing" : "Building"} the Electron app…`);
-	run(
+	runIn(
 		`${useNpm ? "npx --no-install" : "yarn run"} electron-builder --${platform} ${
 			release ? "--publish always" : ""
-		}`,
+		}`, root
 	);
 };
 

--- a/index.js
+++ b/index.js
@@ -23,9 +23,11 @@ const exit = msg => {
 const run = cmd => execSync(cmd, { encoding: "utf8", stdio: "inherit" });
 
 /**
- * Executes the provided shell command in a given working directory and redirects stdout/stderr to the console
+ * Executes the provided shell command in a given working directory and redirects stdout/stderr to
+ * the console
  */
-const runIn = (cmd, directory) => execSync(cmd, { encoding: "utf8", stdio: "inherit", cwd: directory });
+const runIn = (cmd, directory) =>
+	execSync(cmd, { encoding: "utf8", stdio: "inherit", cwd: directory });
 
 /**
  * Returns whether NPM should be used to run commands (instead of Yarn, which is the default)
@@ -82,7 +84,7 @@ const setEnvVariable = (name, value) => {
 const runAction = () => {
 	const platform = getPlatform();
 	const release = getEnvVariable("release") === "true";
-	const root = getEnvVariable("application_root") || null
+	const root = getEnvVariable("application_root") || null;
 
 	// Make sure `package.json` file exists
 	verifyPackageJson();
@@ -123,7 +125,8 @@ const runAction = () => {
 	runIn(
 		`${useNpm ? "npx --no-install" : "yarn run"} electron-builder --${platform} ${
 			release ? "--publish always" : ""
-		}`, root
+		}`,
+		root,
 	);
 };
 

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ const setEnvVariable = (name, value) => {
 const runAction = () => {
 	const platform = getPlatform();
 	const release = getEnvVariable("release") === "true";
-	const root = getEnvVariable("application_root") || null;
+	const appRoot = getEnvVariable("app_root") || null;
 
 	// Make sure `package.json` file exists
 	verifyPackageJson();
@@ -126,7 +126,7 @@ const runAction = () => {
 		`${useNpm ? "npx --no-install" : "yarn run"} electron-builder --${platform} ${
 			release ? "--publish always" : ""
 		}`,
-		root,
+		appRoot,
 	);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "action-electron-builder",
-	"version": "1.1.0",
+	"version": "1.0.0",
 	"description": "GitHub Action for building and releasing Electron apps",
 	"author": {
 		"name": "Samuel Meuli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "action-electron-builder",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "GitHub Action for building and releasing Electron apps",
 	"author": {
 		"name": "Samuel Meuli",


### PR DESCRIPTION
Add ability to specify a working directory for running `electron-builder`. Helps when developing an electron application inside a monorepo. Should be none breaking. First action contribution, open to suggestions on everything. Not sure how to test the script, would be willing to try and document process.