### PR TITLE
electron-builder configuration CLI overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ After building successfully, the action will publish your release artifacts. By 
 You can configure the action further with the following options:
 
 - `package_root`: Directory where NPM/Yarn commands should be run (default: `"."`)
+- `config_overrides`: Object of `electron-builder` configuration overrides. Example:
+```
+config_overrides: >
+  {
+    "extraMetadata": {
+      "version": "4.3.2-snapshot"
+    },
+    "linux": {
+      "target": "deb"
+    }
+  }
+```
+The above is passed to the `electron-builder build` command as `-c.extraMetadata.version=4.3.2-snapshot -c.linux.target=deb`.
 
 See [`action.yml`](./action.yml) for a list of all possible input variables.
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ You can configure the action further with the following options:
 
 - `package_root`: Directory where NPM/Yarn commands should be run (default: `"."`)
 - `config_overrides`: Object of `electron-builder` configuration overrides. Example:
+
 ```
 config_overrides: >
   {
@@ -84,6 +85,7 @@ config_overrides: >
     }
   }
 ```
+
 The above is passed to the `electron-builder build` command as `-c.extraMetadata.version=4.3.2-snapshot -c.linux.target=deb`.
 
 See [`action.yml`](./action.yml) for a list of all possible input variables.

--- a/action.yml
+++ b/action.yml
@@ -3,8 +3,8 @@ author: Samuel Meuli
 description: GitHub Action for building and releasing Electron apps
 
 inputs:
-  extra_metadata:
-    description: Configuration overrides passed directly to electron-builder as --config.extraMetadata. E.g.,  set package.json property `foo` to `bar`
+  config_overrides:
+    description: Configuration overrides passed directly to electron-builder as --config CLI args.
     required: false
   github_token:
     description: GitHub authentication token

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,9 @@ author: Samuel Meuli
 description: GitHub Action for building and releasing Electron apps
 
 inputs:
+  extra_metadata:
+    description: Configuration overrides passed directly to electron-builder as --config.extraMetadata. E.g.,  set package.json property `foo` to `bar`
+    required: false
   github_token:
     description: GitHub authentication token
     required: true

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ const runAction = () => {
 	const platform = getPlatform();
 	const release = getInput("release", true) === "true";
 	const pkgRoot = getInput("package_root", true);
-	const extraMetadata = getInput("extra_metadata") || {};
+	const extraMetadata = JSON.parse(getInput("extra_metadata") || "{}");
 
 	// TODO: Deprecated option, remove in v2.0. `electron-builder` always requires a `package.json` in
 	// the same directory as the Electron app, so the `package_root` option should be used instead

--- a/index.js
+++ b/index.js
@@ -135,6 +135,7 @@ const runAction = () => {
 		...extraMetadataArgs
 	].join(" ");
 
+	log(`Running: ${script}`);
 	run(script, appRoot);
 };
 

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ const runAction = () => {
 	}
 
 	log(`Building${release ? " and releasing" : ""} the Electron app…`);
-	const extraMetadata = getEnv("extra_metadata");
+	const extraMetadata = getInput("extra_metadata");
 	console.log("\n Extra metadata", JSON.parse(extraMetadata));
 	run(
 		`${useNpm ? "npx --no-install" : "yarn run"} electron-builder --${platform} ${

--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ const runAction = () => {
 
 	log(`Building${release ? " and releasing" : ""} the Electron app…`);
 	const extraMetadata = getEnv("extra_metadata");
-	console.log("\n Extra metadata", extraMetadata);
+	console.log("\n Extra metadata", JSON.parse(extraMetadata));
 	run(
 		`${useNpm ? "npx --no-install" : "yarn run"} electron-builder --${platform} ${
 			release ? "--publish always" : ""

--- a/index.js
+++ b/index.js
@@ -117,6 +117,8 @@ const runAction = () => {
 	}
 
 	log(`Building${release ? " and releasing" : ""} the Electron app…`);
+	const extraMetadata = getEnv("extra_metadata");
+	console.log("\n Extra metadata", extraMetadata);
 	run(
 		`${useNpm ? "npx --no-install" : "yarn run"} electron-builder --${platform} ${
 			release ? "--publish always" : ""

--- a/index.js
+++ b/index.js
@@ -60,24 +60,23 @@ const getInput = (name, required) => {
 	return value;
 };
 
-/* 
+/*
  * Taken from https://stackoverflow.com/a/5878101.
  *
  * Function to test if an object is a plain object, i.e. is constructed
  * by the built-in Object constructor and inherits directly from Object.prototype
- * or null (e.g., const foo = Object.create(null)). Some built-in objects pass the test, 
+ * or null (e.g., const foo = Object.create(null)). Some built-in objects pass the test,
  * e.g. Math which is a plain object and some host or exotic objects may pass also.
  */
-const isPlainObject = (obj) => {
+const isPlainObject = obj => {
 	// Basic check for type object that's not null
 	if (typeof obj === "object" && obj !== null) {
-
 		// If Object.getPrototypeOf supported, use it
 		if (typeof Object.getPrototypeOf === "function") {
 			const proto = Object.getPrototypeOf(obj);
 			return proto === Object.prototype || proto === null;
 		}
-		
+
 		// Otherwise, use internal class
 		// This should be reliable as if getPrototypeOf not supported, is pre-ES5
 		return Object.prototype.toString.call(obj) === "[object Object]";
@@ -85,12 +84,12 @@ const isPlainObject = (obj) => {
 
 	// Not an object
 	return false;
-}
+};
 
 /**
- * Given configuration overrides as object, return a list of CLI args that can be 
+ * Given configuration overrides as object, return a list of CLI args that can be
  * passed directly to `electron-builder build` using its `-c...` override mechanism.
- * 
+ *
  * Example, given:
  * {
  *   extraMetadata: {
@@ -101,13 +100,13 @@ const isPlainObject = (obj) => {
  *       releaseNotes: "Some notes",
  *   },
  * }
- * 
+ *
  * Return:
- * ["-c.releaseInfo.releaseNotes=Some notes", 
- *  "-c.releaseInfo.releaseName=foo", 
+ * ["-c.releaseInfo.releaseNotes=Some notes",
+ *  "-c.releaseInfo.releaseName=foo",
  *  "-c.extraMetadata.version=4.1.0"]
  */
-const transformConfigOverridesToCliArgs = (overrides) => {
+const transformConfigOverridesToCliArgs = overrides => {
 	const stack = Object.entries(overrides);
 	const cliArgs = [];
 
@@ -117,7 +116,7 @@ const transformConfigOverridesToCliArgs = (overrides) => {
 			cliArgs.push(`-c.${path}=${config}`);
 		} else {
 			Object.entries(config).forEach(([key, subConfig]) => {
-				stack.push([`${path}.${key}`, subConfig])
+				stack.push([`${path}.${key}`, subConfig]);
 			});
 		}
 	}
@@ -184,19 +183,13 @@ const runAction = () => {
 
 	log(`Building${release ? " and releasing" : ""} the Electron app…`);
 
-	const runner = useNpm ? "npx --no-install" : "yarn run"
+	const runner = useNpm ? "npx --no-install" : "yarn run";
 	const executable = "electron-builder";
 	const platformArg = `--${platform}`;
-	const releaseArg = release ? "--publish always" : ""
+	const releaseArg = release ? "--publish always" : "";
 	const configOverrideArgs = transformConfigOverridesToCliArgs(configOverrides);
 
-	const script = [
-		runner,
-		executable,
-		platformArg,
-		releaseArg,
-		...configOverrideArgs
-	].join(" ");
+	const script = [runner, executable, platformArg, releaseArg, ...configOverrideArgs].join(" ");
 
 	log(`Running: ${script}`);
 	run(script, appRoot);

--- a/index.js
+++ b/index.js
@@ -70,17 +70,17 @@ const getInput = (name, required) => {
  */
 const isPlainObject = (obj) => {
 	// Basic check for type object that's not null
-	if (typeof obj == "object" && obj !== null) {
+	if (typeof obj === "object" && obj !== null) {
 
 		// If Object.getPrototypeOf supported, use it
-		if (typeof Object.getPrototypeOf == "function") {
-			var proto = Object.getPrototypeOf(obj);
+		if (typeof Object.getPrototypeOf === "function") {
+			const proto = Object.getPrototypeOf(obj);
 			return proto === Object.prototype || proto === null;
 		}
 		
 		// Otherwise, use internal class
 		// This should be reliable as if getPrototypeOf not supported, is pre-ES5
-		return Object.prototype.toString.call(obj) == "[object Object]";
+		return Object.prototype.toString.call(obj) === "[object Object]";
 	}
 
 	// Not an object
@@ -103,19 +103,21 @@ const isPlainObject = (obj) => {
  * }
  * 
  * Return:
- * ["-c.releaseInfo.releaseNotes=Some notes", "-c.releaseInfo.releaseName=foo", "-c.extraMetadata.version=4.1.0"]
+ * ["-c.releaseInfo.releaseNotes=Some notes", 
+ *  "-c.releaseInfo.releaseName=foo", 
+ *  "-c.extraMetadata.version=4.1.0"]
  */
 const transformConfigOverridesToCliArgs = (overrides) => {
 	const stack = Object.entries(overrides);
 	const cliArgs = [];
 
 	while (stack.length) {
-		const [path, value] = stack.pop();
-		if (!isPlainObject(value)) {
-			cliArgs.push(`-c.${path}=${value}`);
+		const [path, config] = stack.pop();
+		if (!isPlainObject(config)) {
+			cliArgs.push(`-c.${path}=${config}`);
 		} else {
-			Object.entries(value).forEach(([key, value]) => {
-				stack.push([`${path}.${key}`, value])
+			Object.entries(config).forEach(([key, subConfig]) => {
+				stack.push([`${path}.${key}`, subConfig])
 			});
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -106,7 +106,8 @@ const runAction = () => {
 	// Run NPM build script if it exists
 	log("Running the build script…");
 	if (useNpm) {
-		run("npm run build --if-present", pkgRoot);
+		// TODO
+		// run("npm run build --if-present", pkgRoot);
 	} else {
 		// TODO: Use `yarn run build --if-present` once supported
 		// https://github.com/yarnpkg/yarn/issues/6894
@@ -119,12 +120,12 @@ const runAction = () => {
 	log(`Building${release ? " and releasing" : ""} the Electron app…`);
 	const extraMetadata = getInput("extra_metadata");
 	console.log("\n Extra metadata", JSON.parse(extraMetadata));
-	run(
-		`${useNpm ? "npx --no-install" : "yarn run"} electron-builder --${platform} ${
-			release ? "--publish always" : ""
-		}`,
-		appRoot,
-	);
+	// run(
+	// 	`${useNpm ? "npx --no-install" : "yarn run"} electron-builder --${platform} ${
+	// 		release ? "--publish always" : ""
+	// 	}`,
+	// 	appRoot,
+	// );
 };
 
 runAction();

--- a/index.js
+++ b/index.js
@@ -60,6 +60,10 @@ const getInput = (name, required) => {
 	return value;
 };
 
+const isPlainObject = (value) => {
+	return Object.prototype.toString.call(value) === "[object Object]";
+}
+
 /**
  * Installs NPM dependencies and builds/releases the Electron app
  */
@@ -67,7 +71,7 @@ const runAction = () => {
 	const platform = getPlatform();
 	const release = getInput("release", true) === "true";
 	const pkgRoot = getInput("package_root", true);
-	const extraMetadata = JSON.parse(getInput("extra_metadata") || "{}");
+	const configOverrides = JSON.parse(getInput("config_overrides") || "{}");
 
 	// TODO: Deprecated option, remove in v2.0. `electron-builder` always requires a `package.json` in
 	// the same directory as the Electron app, so the `package_root` option should be used instead
@@ -123,7 +127,10 @@ const runAction = () => {
 	const executable = "electron-builder";
 	const platformArg = `--${platform}`;
 	const releaseArg = release ? "--publish always" : ""
-	const extraMetadataArgs = Object.entries(extraMetadata).map(([key, value]) => {
+	const configOverrideArgs = Object.entries(configOverrides).map(([key, value]) => {
+		if (isPlainObject(value)) {
+
+		}
 		return `-c.extraMetadata.${key}=${value}`;
 	});
 
@@ -132,7 +139,7 @@ const runAction = () => {
 		executable,
 		platformArg,
 		releaseArg,
-		...extraMetadataArgs
+		...configOverrideArgs
 	].join(" ");
 
 	log(`Running: ${script}`);


### PR DESCRIPTION
Hi there,

I just started using this Github action--extremely useful, thank you for it. One piece that I found missing for my use case is the ability to pass a configuration override (e.g., `-c.extraMetadata.foo=bar`) directly to the `electron-builder build` command. 

This PR accomplish that in a generic way. From a consumer's workflow yml file, a user can now pass a `config_overrides` object as a JSON string to this action, which will transform it into a properly formed `-c.x.y.z=value` config CLI arg. For example, passing:
```
config_overrides: >
  {
    "extraMetadata": {
      "version": "4.3.2-snapshot",
      "foo": "bar
    },
    "linux": {
      "target": "deb"
    }
  }
```
will be passed through to the `electron-builder build` command as `-c.extraMetadata.version=4.3.2-snapshot -c.extraMetadata.foo=bar -c.linux.target=deb`.

Let me know what you think! Thanks for the consideration,
Gabe