### PR TITLE
Fix missing `args` input in `action.yml`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,10 @@ inputs:
     description: Whether to run `electron-builder` using the Vue CLI plugin instead of calling the command directly
     required: false
     default: false
+  args:
+    description: Other arguments to pass to the `electron-builder` command, e.g. configuration overrides
+    required: false
+    default: ""
 
   # Deprecated
   app_root:


### PR DESCRIPTION
I've seen you've added the option to add custom args in 1.5.0 (e3c7eb42d842357ee55e9148a9861386489661c5) but you forgot to add the new option to the `action.yml` and therefor it throws an error when using it: 

```
##[warning]Unexpected input 'args', valid inputs are ['github_token', 'mac_certs', 'mac_certs_password', 'release', 'windows_certs', 'windows_certs_password', 'package_root', 'build_script_name', 'skip_build', 'use_vue_cli', 'app_root']
Run samuelmeuli/action-electron-builder@v1

Will run NPM commands in directory "."
```
As you can see in this pipeline run [here](https://github.com/MarcMogdanz/AnimeIRC/runs/723779095?check_suite_focus=true).

I've just added the option and [already ran it](https://github.com/MarcMogdanz/AnimeIRC/runs/723810348?check_suite_focus=true) and it worked but feel free to test it yourself before merging! Thanks for your action!