### PR TITLE
✨ Add `skip_install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ You can configure the action further with the following options:
 - `package_root`: Directory where NPM/Yarn commands should be run (default: `"."`)
 - `build_script_name`: Name of the optional NPM build script which is executed before `electron-builder` (default: `"build"`)
 - `skip_build`: Whether the action should execute the NPM build script before running `electron-builder`
+- `skip_install`: Whether the action should execute the NPM install script before running build.
 - `use_vue_cli`: Whether to run `electron-builder` using the [Vue CLI plugin](https://nklayman.github.io/vue-cli-plugin-electron-builder) instead of calling the command directly
 - `args`: Other arguments to pass to the `electron-builder` command, e.g. configuration overrides (default: `""`)
 - `max_attempts`: Maximum number of attempts for completing the build and release step (default: `1`)

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: Whether the action should execute the NPM build script before running `electron-builder`
     required: false
     default: false
+  skip_install:
+    description: Whether the action should execute NPM install script
+    required: false
+    default: false
   use_vue_cli:
     description: Whether to run `electron-builder` using the Vue CLI plugin instead of calling the command directly
     required: false

--- a/index.js
+++ b/index.js
@@ -69,6 +69,8 @@ const runAction = () => {
 	const pkgRoot = getInput("package_root", true);
 	const buildScriptName = getInput("build_script_name", true);
 	const skipBuild = getInput("skip_build") === "true";
+	const skipInstall = getInput("skip_install") === "true";
+
 	const useVueCli = getInput("use_vue_cli") === "true";
 	const args = getInput("args") || "";
 	const maxAttempts = Number(getInput("max_attempts") || "1");
@@ -104,9 +106,12 @@ const runAction = () => {
 
 	// Disable console advertisements during install phase
 	setEnv("ADBLOCK", true);
-
-	log(`Installing dependencies using ${useNpm ? "NPM" : "Yarn"}…`);
-	run(useNpm ? "npm install" : "yarn", pkgRoot);
+	if (skipInstall) {
+		log("Skipping install script because `skip_install` option is set");
+	} else {
+		log(`Installing dependencies using ${useNpm ? "NPM" : "Yarn"}…`);
+		run(useNpm ? "npm install" : "yarn", pkgRoot);
+	}
 
 	// Run NPM build script if it exists
 	if (skipBuild) {


### PR DESCRIPTION
Already has a `skip_build` option I think a `skip_install` in the same vain can be useful for people who want to cache package installation or use something like `pnpm`

It is a very minor change hence didn't make a detailed PR